### PR TITLE
All formula updated to pass (most) strict auditing

### DIFF
--- a/fonttools.rb
+++ b/fonttools.rb
@@ -1,9 +1,9 @@
-require "formula"
-
 class Fonttools < Formula
+  desc "Python library for manipulating fonts"
   homepage "https://github.com/behdad/fonttools"
   url "https://github.com/behdad/fonttools/archive/3.0.tar.gz"
-  sha256 "bab4046b1777f4b4a7002c8ebe44a977610d1473a9f6fec23dc7d1b891dcec20"
+  sha256 "3bc9141d608603faac3f800482feec78a550d0a94c29ff3850471dbe4ad9e941"
+
   head "https://github.com/behdad/fonttools.git"
 
   depends_on :python if MacOS.version <= :snow_leopard
@@ -16,5 +16,10 @@ class Fonttools < Formula
 
     bin.install Dir["#{libexec}/bin/*"]
     bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
+  end
+
+  test do
+    cp "/Library/Fonts/Arial.ttf", testpath
+    system bin/"ttx", "Arial.ttf"
   end
 end

--- a/ots.rb
+++ b/ots.rb
@@ -1,24 +1,25 @@
-require "formula"
-
 class Ots < Formula
+  desc "OpenType Sanitiser parses validates & sanitizes OpenType & WOFF2 font files"
   homepage "https://github.com/khaledhosny/ots"
-  url "https://github.com/khaledhosny/ots/releases/download/v5.0.0/ots-5.0.0.tar.gz"
-  sha256 "f5ceb4ab999376dbec6d4262947dc38f2c353c392ae7d0f4814276a641952e52"
-  version "5.0.0"
+  url "https://github.com/khaledhosny/ots/releases/download/v5.0.1/ots-5.0.1.tar.gz"
+  sha256 "548cdb7a44b4ca67fd0861626a75874a72be893f7a7faee5709d473456b3232c"
+
   head "https://github.com/khaledhosny/ots.git"
 
-  head do
-    depends_on "autoconf"   => :build
-    depends_on "automake"   => :build
-    depends_on "libtool"    => :build
-    depends_on "pkg-config" => :build
-  end
+  depends_on "autoconf"   => :build
+  depends_on "automake"   => :build
+  depends_on "libtool"    => :build
+  depends_on "pkg-config" => :build
 
   def install
     system "./autogen.sh" if build.head?
     system "./configure"
-    system "make CXXFLAGS=-DOTS_DEBUG"
+    system "make", "CXXFLAGS=-DOTS_DEBUG"
     bin.install "perf"
     bin.install "ot-sanitise"
+  end
+
+  test do
+    system "ot-sanitise", "--version"
   end
 end

--- a/sfnt2woff-zopfli.rb
+++ b/sfnt2woff-zopfli.rb
@@ -1,10 +1,10 @@
-require "formula"
 require "base64"
 
 class Sfnt2woffZopfli < Formula
+  desc "WOFF utilities with Zopfli compression"
   homepage "https://github.com/bramstein/sfnt2woff-zopfli"
   url "https://github.com/bramstein/sfnt2woff-zopfli/archive/v1.0.1.tar.gz"
-  sha256 "0da173a3f50ce4bb6b4817b3fcebb55a28c95546b852824f9cb16afefa8db45b"
+  sha256 "135a211bdafdbd05a892ff627838f8822697f60154cfae371e08ad451207206f"
 
   def install
     system "make"

--- a/sfnt2woff.rb
+++ b/sfnt2woff.rb
@@ -1,10 +1,9 @@
-require "formula"
-
 class Sfnt2woff < Formula
+  desc "Convert existing TrueType/OpenType fonts to WOFF format"
   homepage "http://people.mozilla.org/~jkew/woff/"
   url "http://people.mozilla.org/~jkew/woff/woff-code-latest.zip"
+  version "2009-10-04"
   sha256 "7713630d2f43320a1d92e2dbb014ca3201caab1dd4c0ab92816016824c680d96"
-  version "2014-12-18"
 
   def install
     system "make"

--- a/sfntly.rb
+++ b/sfntly.rb
@@ -1,18 +1,22 @@
-require "formula"
-
 class Sfntly < Formula
-  homepage "https://code.google.com/p/sfntly/"
-  url "http://sfntly.googlecode.com/svn/trunk/java/", :using => :svn, :revision => 239
-  version '239'
+  desc "Library for Using, Editing, and Creating SFNT-based Fonts"
+  homepage "https://github.com/googlei18n/sfntly"
+  url "https://github.com/googlei18n/sfntly.git", :revision => "b18b09b6114b9b7fe6fc2f96d8b15e8a72f66916"
+  version "2016-07-27"
 
   depends_on :ant => :build
 
   def install
-    system "ant"
-    libexec.install "dist/lib/sfntly.jar"
-    libexec.install "dist/tools/sfnttool/sfnttool.jar"
-    libexec.install "dist/tools/fontinfo/fontinfo.jar"
+    system "ant", "-f", "java/build.xml"
+    libexec.install "java/dist/lib/sfntly.jar"
+    libexec.install "java/dist/tools/sfnttool/sfnttool.jar"
+    libexec.install "java/dist/tools/fontinfo/fontinfo.jar"
     bin.write_jar_script libexec/"sfnttool.jar", "sfnttool"
     bin.write_jar_script libexec/"fontinfo.jar", "fontinfo"
+  end
+
+  test do
+    system "fontinfo", "-h"
+    system "sfnttool", "-help"
   end
 end

--- a/ttf2eot.rb
+++ b/ttf2eot.rb
@@ -1,8 +1,7 @@
-require "formula"
-
 class Ttf2eot < Formula
-  homepage "https://code.google.com/p/ttf2eot/"
-  url "https://ttf2eot.googlecode.com/files/ttf2eot-0.0.2-2.tar.gz"
+  desc "Very small utility to convert TTF files to EOT"
+  homepage "https://code.google.com/archive/p/ttf2eot/"
+  url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ttf2eot/ttf2eot-0.0.2-2.tar.gz"
   sha256 "023cf04d7c717657e92afe566518bf2a696ab22a2a8eba764340000bebff8db8"
 
   def install

--- a/vfb2ufo.rb
+++ b/vfb2ufo.rb
@@ -1,15 +1,15 @@
 class Vfb2ufo < Formula
-  desc "Font converter that transforms FontLab VFB files into UFO (and back again)"
+  desc "Two-way converter for VFB and UFO (or UFOZ)"
   homepage "http://blog.fontlab.com/font-utility/vfb2ufo/"
   url "http://www.fontlab.us/downloads/installers/vfb2ufoMac.zip"
   version "2015-01-23"
   sha256 "bba50c7ec94c3f8d112be368e2532bd0e4b97047b6059734f5b2e46031b70671"
 
   def install
-    bin.install 'vfb2ufoMac/bin/vfb2ufo'
+    bin.install "vfb2ufoMac/bin/vfb2ufo"
   end
 
   test do
-    system "vfb2ufo"
+    system "vfb2ufo", "-h"
   end
 end

--- a/woff2.rb
+++ b/woff2.rb
@@ -1,8 +1,7 @@
-require "formula"
-
 class Woff2 < Formula
+  desc "Compress fonts with Brotli into WOFF2 format"
   homepage "https://github.com/google/woff2"
-  url "https://github.com/google/woff2.git", :revision => "3fdb28894a18f1176334595fc486d86cbe6ad68b", :using => :git
+  url "https://github.com/google/woff2.git", :revision => "afbecce5ff16faf92ce637eab991810f5b66f803"
 
   def install
     system "make"


### PR DESCRIPTION
- all formula updated to pass strict auditing
- Upgrade ots from 5.0.0 to 5.0.1
- Upgrade woff2 from 2015-07-13 to 2016-05-25
- some sha256 sums were wrong (my fault; do not curl GitHub download
  URLs for checksums
- repaired sfntly installation (moved to GitHub)
- added some basic tests to most formulas

Remaining unsolved audits:
- sfnt2woff, ttf2eot, and woff2 require tests:

```
$ brew audit --strict --online sfnt2woff
sfnt2woff:
  * A `test do` test block should be added
Error: 1 problem in 1 formula

$ brew audit --strict --online ttf2eot.rb
ttf2eot:
  * A `test do` test block should be added
Error: 1 problem in 1 formula

$ brew audit --strict --online woff2.rb
woff2:
  * A `test do` test block should be added
Error: 1 problem in 1 formula
```
- Not sure why this is happening (the website exists without any
  redirects required):

```
$ brew audit --strict --online vfb2ufo.rb
vfb2ufo:
  * The homepage is not reachable (curl exit code 22)
Error: 1 problem in 1 formula
```
- Some tests are really basic and low-quality and could use improvement
  in the future.
