### PR TITLE
Update depends_on syntax to silence warning

### DIFF
--- a/sfntly.rb
+++ b/sfntly.rb
@@ -4,7 +4,7 @@ class Sfntly < Formula
   url "https://github.com/googlei18n/sfntly"
   version '239'
 
-  depends_on :ant => :build
+  depends_on "ant" => :build
 
   def install
     system "ant", "-f", "java/build.xml"


### PR DESCRIPTION
The following warning in displayed when installing `sfntly`:

```
Warning: Calling 'depends_on :ant' is deprecated!
Use 'depends_on "ant"' instead.
/usr/local/Homebrew/Library/Taps/bramstein/homebrew-webfonttools/sfntly.rb:7:in `<class:Sfntly>'
```

New syntax just expects a string instead of a symbol: http://www.rubydoc.info/github/Homebrew/brew/Formula.depends_on